### PR TITLE
Remove session_number and task_protocol columns

### DIFF
--- a/analysis_crons/subject_trials_aggregates.py
+++ b/analysis_crons/subject_trials_aggregates.py
@@ -16,7 +16,7 @@ import globus_sdk as globus
 
 from one.alf import io as alfio, files as alfiles
 from iblutil.io import hashfile, params
-from ibllib.io.extractors.training_trials import PhasePosQuiescence, StimOnTriggerTimes
+from ibllib.io.extractors.training_trials import StimOnTriggerTimes
 
 """
 Generate per subject trials aggregate files for all culled subjects that have at least one session with an ibl project
@@ -43,6 +43,10 @@ SETTING UP
 ===========
 '''
 
+# Flags
+dry = True  # Only tell me which files would be created, don't do anything
+only_new_subjects = True  # Only create aggregates for subjects that don't have an aggregate yet, don't check for update
+
 # Settings
 root_path = Path('/mnt/ibl')
 output_path = Path('/mnt/ibl/aggregates/')
@@ -50,7 +54,6 @@ collection = 'Subjects'
 file_name = '_ibl_subjectTrials.table.pqt'
 alyx_user = 'julia.huntenburg'
 version = 1.0
-dry = True
 
 # Set up
 output_path.mkdir(exist_ok=True, parents=True)
@@ -144,6 +147,9 @@ for i, sub in enumerate(subjects):
         ds = Dataset.objects.filter(id=ds_id)
         # If there is exactly one default dataset, check if it needs updating
         if ds.count() == 1:
+            if only_new_subjects:
+                logger.info('...aggregate exists and only_new_subjects=True, skipping')
+                continue
             if ds.first().revision is None:
                 out_file = output_path.joinpath(collection, sub.lab.name, sub.nickname, file_name)
             else:
@@ -208,10 +214,12 @@ for i, sub in enumerate(subjects):
             trials['session_start_time'] = t.session.start_time
 
             # Load quiescence and stimOn_trigger and add to the table
-            (*_, quiescence), _ = PhasePosQuiescence(alf_path.parent).extract(save=False)
+            quiescence = alfio.load_object(alf_path, 'trials',
+                                           attribute='quiescencePeriod', short_keys=True)['quiescencePeriod']
             stimon_trigger, _ = StimOnTriggerTimes(alf_path.parent).extract(save=False)
             trials['quiescence'] = quiescence
             trials['stimOnTrigger_times'] = stimon_trigger
+            # TODO: Add protocol number
             # Add to list of trials for subject
             all_trials.append(trials)
 


### PR DESCRIPTION
Removed `session_number` and `task_protocol` columns from the subjectTrials aggregate as these columns are present in the ONE sessions cache table, readily available to all users.  The tables can be joined thus:

```
trials = one.load_aggregate('subjects', subject, '_ibl_subjectTrials.table')
trials = (trials
          .set_index('session')
          .join(one._cache.sessions.drop('date', axis=1)))
```

This makes joining the tables simpler as there are now duplicate columns (i.e. task_protocol), reduces space on disk and improves data integrity as there is no chance of data conflict.  The down side is that currently the sessions cache table is not registered on Alyx and as such isn't protected by revisions.

If we do this we should remove these columns from the existing tables so that users don't need to check for the columns to drop.