### PR TITLE
bugfix for OneSdsc.load_object()

### DIFF
--- a/deploy/iblsdsc.py
+++ b/deploy/iblsdsc.py
@@ -42,7 +42,7 @@ class OneSdsc(OneAlyx):
         if isinstance(obj, list) or not self.uuid_filenames:
             return obj
         # pops the UUID in the key names
-        for k in obj.keys():
+        for k in list(obj.keys()):
             new_key = '.'.join(filterfalse(is_uuid_string, k.split('.')))
             obj[new_key] = obj.pop(k)
         return obj


### PR DESCRIPTION
original version raises:
```
RuntimeError: dictionary keys changed during iteration
```
because `dict.keys()` returns a view. `list()` should fix it by making an explicit copy