### PR TITLE
Changed the logs output using tee command

### DIFF
--- a/deploy/serverpc/crontab/02_other_jobs.sh
+++ b/deploy/serverpc/crontab/02_other_jobs.sh
@@ -16,12 +16,12 @@ while true; do
     printf "\n$(date)\n" ;
     printf "Checking iblenv for updates\n" ;
     printf "Logging to /var/log/ibl/update_iblenv.log\n" ;
-    ./update_iblenv.sh > /var/log/ibl/update_iblenv.log 2>&1 ;
+    ./update_iblenv.sh 2>&1 | tee /var/log/ibl/update_iblenv.log ;
 
     printf "\n$(date)\n" ;
     printf "Running maintenance script\n" ;
     printf "Logging to /var/log/ibl/maintenance_jobs.log\n" ;
-    python maintenance_jobs.py > /var/log/ibl/maintenance_jobs.log 2>&1 ;
+    python maintenance_jobs.py 2>&1 | tee  /var/log/ibl/maintenance_jobs.log ;
 
     # Reset time to next update to time until next midnight (in seconds) and restart counting elapsed seconds
     env_update_in=$(expr `date -d "tomorrow 0" +%s` - `date -d "now" +%s`) ;
@@ -33,7 +33,7 @@ while true; do
     printf "\n$(date)\n" ;
     printf "Running health report and creating jobs\n" ;
     printf "Logging to /var/log/ibl/report_create_jobs.log\n" ;
-    python report_create_jobs.py >> /var/log/ibl/report_create_jobs.log 2>&1 ;
+    python report_create_jobs.py 2>&1 | tee -a /var/log/ibl/report_create_jobs.log ;
     report_create_last=$SECONDS  # reset the timer
   fi
 
@@ -41,7 +41,7 @@ while true; do
   printf "\n$(date)\n" ;
   printf "Running next set of small jobs from the queue\n" ;
   printf "Logging to /var/log/ibl/small_jobs.log\n" ;
-  python small_jobs.py >> /var/log/ibl/small_jobs.log 2>&1 ;
+  python small_jobs.py 2>&1 | tee -a /var/log/ibl/small_jobs.log ;
 
   # Repeat
 done


### PR DESCRIPTION
Hi @k1o0 
I made the changes we discussed last week for the detailed logs on whiterussian. 

I saw the logs on whiterussian, and the tail of the report_create_jobs.log looks like the following. 
```bash
2026-03-02 10:43:21 INFO     local_server.py:117  creating session for /mnt/s0/Data/Subjects/SP066/2025-06-04/001
2026-03-02 10:43:22 ERROR    local_server.py:138  Failed to register session SP066/2025-06-04/001:
Traceback (most recent call last):
  File "/home/ibladmin/Documents/PYTHON/envs/iblenv/lib/python3.12/site-packages/ibllib/pipes/local_server.py", line 122, in job_creator
    rc.register_session(session_path, file_list=False)
  File "/home/ibladmin/Documents/PYTHON/envs/iblenv/lib/python3.12/site-packages/ibllib/oneibl/registration.py", line 241, in register_session
    assert len(session) != 0, 'no session on Alyx and no tasks in experiment description'
           ^^^^^^^^^^^^^^^^^
AssertionError: no session on Alyx and no tasks in experiment description

2026-03-02 10:43:22 INFO     report_create_jobs.py:57   Ran job creator.
2026-03-02 10:43:22 INFO     tasks.py:270  Job <class '__main__.JobCreator'> complete
2026-03-02 10:43:22 INFO     tasks.py:294  N outputs: 0
2026-03-02 10:43:22 INFO     tasks.py:295  --- 34.415974617004395 seconds run-time ---
```

And with the current change all these logs along with the small_job logs will be appended to `other_jobs.log` file.

And from what I understand these changes will be propogated to all the local servers and not just whiterussian.

Is this what we wanted?
