### PR TITLE
update dlc+lp imports from iblvideo

### DIFF
--- a/deploy/serverpc/dlc/run_dlc.py
+++ b/deploy/serverpc/dlc/run_dlc.py
@@ -1,7 +1,6 @@
 import argparse
 from pathlib import Path
-from iblvideo import download_weights
-from iblvideo.pose_dlc import dlc
+from iblvideo import download_weights, dlc
 
 
 if __name__ == "__main__":

--- a/deploy/serverpc/dlc/run_dlc.py
+++ b/deploy/serverpc/dlc/run_dlc.py
@@ -1,7 +1,7 @@
 import argparse
 from pathlib import Path
 from iblvideo import download_weights
-from iblvideo.choiceworld import dlc
+from iblvideo.pose_dlc import dlc
 
 
 if __name__ == "__main__":

--- a/deploy/serverpc/litaction/run_litaction.py
+++ b/deploy/serverpc/litaction/run_litaction.py
@@ -1,8 +1,7 @@
 import argparse
 from pathlib import Path
 
-from iblvideo import download_la_models
-from iblvideo.segmentation_la import lightning_action
+from iblvideo import download_la_models, lightning_action
 
 
 if __name__ == '__main__':

--- a/deploy/serverpc/litpose/run_litpose.py
+++ b/deploy/serverpc/litpose/run_litpose.py
@@ -3,8 +3,7 @@ from pathlib import Path
 # import cProfile
 # import pstats
 
-from iblvideo import download_lp_models
-from iblvideo.pose_lp import lightning_pose
+from iblvideo import download_lp_models, lightning_pose
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
the previous import in `run_dlc.py`:
```
from iblvideo.choiceworld import dlc
```
has been deprecated in the `iblvideo` repo in favor of
```
from iblvideo.pose_dlc import dlc
```
